### PR TITLE
Fix null handling for unit entries

### DIFF
--- a/Umrechner.xaml.cs
+++ b/Umrechner.xaml.cs
@@ -15,8 +15,8 @@ public partial class UmrechnerPage : ContentPage
 
         try
         {
-            string from = InputUnit.Text?.Trim().ToLower();
-            string to = OutputUnit.Text?.Trim().ToLower();
+            string from = InputUnit.Text?.Trim()?.ToLower() ?? string.Empty;
+            string to = OutputUnit.Text?.Trim()?.ToLower() ?? string.Empty;
 
             double result = ConvertValue(inputVal, from, to);
             var fromSymbol = units[from].Symbol;


### PR DESCRIPTION
## Summary
- prevent null reference in `UmrechnerPage` when unit fields are empty

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c543cfa88325a3ae4aead6af1797